### PR TITLE
Remove redirect and activate GTB Helper application with Claude Code branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
     <br>
     Based on Tsuchinoninjin's Helper Page
     <br>
-    <small style="color: #666;">Claude Code edited version</small>
+    <small style="color: #666;">Claude Code edited version - 2025</small>
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 
 <!-- Add or remove rows in the old banzuke table if necessary -->
@@ -6,14 +5,151 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=0.5">
-  <script type="text/javascript" src="script.js"></script>
-  <title>GTB Helper</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script type="text/javascript" src="test/redips-drag-min.js"></script>
+  <script type="text/javascript" src="https://momentjs.com/downloads/moment.js"></script>
+  <script type="text/javascript" src="test/script.js"></script>
+  <script async defer src="https://apis.google.com/js/api.js"></script>
+  <script async defer src="https://accounts.google.com/gsi/client"></script>
+  <link rel="stylesheet" href="test/styles.css" type="text/css"/>
+  <title>GTB Helper - Claude Code Edition</title>
 </head>
 <body>
-  <div style="width: 100%;height: 100%;position: absolute;top: 0;left: 0;background: #00000080;z-index: 999;">
-    <div style="width: fit-content;margin: auto;background: white;font-size: xx-large;padding: 2vw;top: 50%;position: relative;transform: translateY(-50%);">Redirecting to new domain...
+  <header>
+    <h1><span id="gtb">Guess the Banzuke </span>Helper Page <small style="color: #666;">(Claude Code Edition)</small></h1>
+    <a href="previous.html">Previous basho</a>
+    <a href="http://sumodb.sumogames.de/gtb/GTBEntry.aspx" target="_blank">GTB Entry Form</a>
+    <br>
+    <ul>
+      <li>Drag and drop rikishi from the old banzuke into the new banzuke</li>
+      <li>Multiple rikishi can occupy a single slot in the new banzuke</li>
+      <li>Click on individual rikishi's rank change to run a SumoDB query with the rikishi's <br>
+          current rank, number of wins and the new rank that will be highlighted.</li>
+      <li>Your every move is automatically saved to the browser's local storage <br>
+          so it will not reset when you refresh the page or close the browser</li>
+    </ul>
+    <div id="doubleClickOptions">
+      <b>Double-click on rikishi</b><br>
+      <label><input type="radio" class="checkbox" name="onDoubleClick" onclick="saveRadio(this)" value="openRikishiPage"> Open Rikishi Information page</label><br>
+      <label><input type="radio" class="checkbox" name="onDoubleClick" onclick="saveRadio(this)" value="returnToOld"> Return it to the old banzuke</label><br>
+      <button id="resetBanzuke" onclick="redips.resetBanzuke()">Reset Changes</button>
+    </div>
+    <div id="saveLoadProgress">
+      <button id="signinButton">Sign in with Google</button>
+      <button id="signoutButton">Sign out</button>
+      <button id="saveToDrive">Save banzuke</button>
+      <button id="loadSave">Load last saved banzuke</button>
+      <span id="messageLine">Save or load your banzuke</span>
+      <span id="progressText"></span>
+    </div>
+  </header>
+  <div id="redips-drag">
+    <div id="tableContainer">
+      <table id="tableLiner" class="mainTable">
+        <tr><td class="banzukeContainer">
+          <table id="banzuke1">
+            <thead>
+              <tr>
+                <th class="tableTitle" colspan="5"></th>
+              </tr>
+              <tr class="theader">
+                <th>East</th><th>Rank</th><th>West</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="san"><td class="redips-only Y1e"></td><th>Y1</th><td class="redips-only Y1w"></td></tr>
+              <tr class="san"><td class="redips-only O1e"></td><th>O1</th><td class="redips-only O1w"></td></tr>
+              <tr class="san"><td class="redips-only S1e"></td><th>S1</th><td class="redips-only S1w"></td></tr>
+              <tr class="san"><td class="redips-only S2e"></td><th>S2</th><td class="redips-only S2w"></td></tr>
+              <tr class="san"><td class="redips-only K1e"></td><th>K1</th><td class="redips-only K1w"></td></tr>
+              <tr class="san"><td class="redips-only K2e"></td><th>K2</th><td class="redips-only K2w"></td></tr>
+
+              <tr><td class="redips-only M1e"></td><th>M1</th><td class="redips-only M1w"></td></tr>
+              <tr><td class="redips-only M2e"></td><th>M2</th><td class="redips-only M2w"></td></tr>
+              <tr><td class="redips-only M3e"></td><th>M3</th><td class="redips-only M3w"></td></tr>
+              <tr><td class="redips-only M4e"></td><th>M4</th><td class="redips-only M4w"></td></tr>
+              <tr><td class="redips-only M5e"></td><th>M5</th><td class="redips-only M5w"></td></tr>
+              <tr><td class="redips-only M6e"></td><th>M6</th><td class="redips-only M6w"></td></tr>
+              <tr><td class="redips-only M7e"></td><th>M7</th><td class="redips-only M7w"></td></tr>
+              <tr><td class="redips-only M8e"></td><th>M8</th><td class="redips-only M8w"></td></tr>
+              <tr><td class="redips-only M9e"></td><th>M9</th><td class="redips-only M9w"></td></tr>
+              <tr><td class="redips-only M10e"></td><th>M10</th><td class="redips-only M10w"></td></tr>
+              <tr><td class="redips-only M11e"></td><th>M11</th><td class="redips-only M11w"></td></tr>
+              <tr><td class="redips-only M12e"></td><th>M12</th><td class="redips-only M12w"></td></tr>
+              <tr><td class="redips-only M13e"></td><th>M13</th><td class="redips-only M13w"></td></tr>
+              <tr><td class="redips-only M14e"></td><th>M14</th><td class="redips-only M14w"></td></tr>
+              <tr><td class="redips-only M15e"></td><th>M15</th><td class="redips-only M15w"></td></tr>
+              <tr><td class="redips-only M16e"></td><th>M16</th><td class="redips-only M16w"></td></tr>
+              <tr><th class="divider" colspan="3"></th></tr>
+              <tr><td class="redips-only J1e"></td><th>J1</th><td class="redips-only J1w"></td></tr>
+              <tr><td class="redips-only J2e"></td><th>J2</th><td class="redips-only J2w"></td></tr>
+              <tr><td class="redips-only J3e"></td><th>J3</th><td class="redips-only J3w"></td></tr>
+              <tr><td class="redips-only J4e"></td><th>J4</th><td class="redips-only J4w"></td></tr>
+              <tr><td class="redips-only J5e"></td><th>J5</th><td class="redips-only J5w"></td></tr>
+              <tr><td class="redips-only J6e"></td><th>J6</th><td class="redips-only J6w"></td></tr>
+              <tr><td class="redips-only J7e"></td><th>J7</th><td class="redips-only J7w"></td></tr>
+              <tr><td class="redips-only J8e"></td><th>J8</th><td class="redips-only J8w"></td></tr>
+              <tr><td class="redips-only J9e"></td><th>J9</th><td class="redips-only J9w"></td></tr>
+              <tr><td class="redips-only J10e"></td><th>J10</th><td class="redips-only J10w"></td></tr>
+              <tr><td class="redips-only J11e"></td><th>J11</th><td class="redips-only J11w"></td></tr>
+              <tr><td class="redips-only J12e"></td><th>J12</th><td class="redips-only J12w"></td></tr>
+              <tr><td class="redips-only J13e"></td><th>J13</th><td class="redips-only J13w"></td></tr>
+              <tr><td class="redips-only J14e"></td><th>J14</th><td class="redips-only J14w"></td></tr>
+            </tbody>
+          </table>
+        </td><td class="banzukeContainer">
+          <table id="banzuke2" class="mainTable">
+            <thead>
+              <tr>
+                <th class="tableTitle" colspan="5"><span id="makRik">0</span> rikishi placed</th>
+              </tr>
+              <tr class="theader">
+                <th class="chHead">Chg.</th><th>East</th><th>Rank</th><th>West</th><th class="chHead">Chg.</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="san"><td class="ch"> </td><td class="redips-only b2"></td><th>Y1</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr class="san"><td class="ch"> </td><td class="redips-only b2"></td><th>Y2</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr class="san"><td class="ch"> </td><td class="redips-only b2"></td><th>O1</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr class="san"><td class="ch"> </td><td class="redips-only b2"></td><th>O2</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr class="san"><td class="ch"> </td><td class="redips-only b2"></td><th>O3</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr class="san"><td class="ch"> </td><td class="redips-only b2"></td><th>S1</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr class="san"><td class="ch"> </td><td class="redips-only b2"></td><th>S2</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr class="san"><td class="ch"> </td><td class="redips-only b2"></td><th>K1</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr class="san"><td class="ch"> </td><td class="redips-only b2"></td><th>K2</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M1</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M2</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M3</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M4</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M5</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M6</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M7</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M8</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M9</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M10</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M11</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M12</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M13</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M14</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M15</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M16</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M17</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>M18</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+              <tr><th class="divider" colspan="5"></th></tr>
+              <tr><td class="ch"> </td><td class="redips-only b2"></td><th>J</th><td class="redips-only b2"></td><td class="ch"> </td></tr>
+            </tbody>
+          </table>
+        </td></tr>
+      </table>
     </div>
   </div>
+  <footer>
+    Created by Chiyotasuke
+    <br>
+    Based on Tsuchinoninjin's Helper Page
+    <br>
+    <small style="color: #666;">Claude Code edited version</small>
+  </footer>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,2 @@
-
-window.onload = function () {
-  window.location.href = "https://gtbhelper.vercel.app/";
-};
+// Removed redirect - now using the actual GTB Helper application
+// This file can be removed or repurposed for other functionality

--- a/test/index.html
+++ b/test/index.html
@@ -12,11 +12,11 @@
   <script async defer src="https://apis.google.com/js/api.js"></script>
   <script async defer src="https://accounts.google.com/gsi/client"></script>
   <link rel="stylesheet" href="styles.css" type="text/css"/>
-  <title>GTB Helper</title>
+  <title>GTB Helper - Claude Code Edition</title>
 </head>
 <body>
   <header>
-    <h1><span id="gtb">Guess the Banzuke </span>Helper Page <small>(NEW)</small></h1>
+    <h1><span id="gtb">Guess the Banzuke </span>Helper Page <small style="color: #666;">(Claude Code Edition)</small></h1>
     <a href="previous.html">Previous basho</a>
     <a href="http://sumodb.sumogames.de/gtb/GTBEntry.aspx" target="_blank">GTB Entry Form</a>
     <br>
@@ -148,6 +148,8 @@
     Created by Chiyotasuke
     <br>
     Based on Tsuchinoninjin's Helper Page
+    <br>
+    <small style="color: #666;">Claude Code edited version</small>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
This PR removes the redirect to gtbhelper.vercel.app and instead serves the actual GTB Helper application directly. The application has been updated with "Claude Code Edition" branding to clearly indicate this is a modified version.

## Key Changes
- Replaced redirect page with full GTB Helper application from test directory
- Added "Claude Code Edition - 2025" branding to title, header, and footer
- Updated all script and style paths to reference test directory files
- Cleared redirect functionality from script.js

## Technical Details
- Main index.html now contains the full banzuke application instead of redirect
- Resource paths updated: `test/redips-drag-min.js`, `test/script.js`, `test/styles.css`
- Maintains all original functionality: drag-and-drop, Google Drive integration, local storage

## Result
Users visiting the site will now see the full GTB Helper application with clear indication that this is the Claude Code edited version, rather than being redirected to another domain.