### PR TITLE
Remove hardcoded retired rikishi and convert to ES6 modules

### DIFF
--- a/basho-utils.js
+++ b/basho-utils.js
@@ -38,10 +38,9 @@ export function getNextBasho(year, month) {
 export function writeTableTitles(endedBashoDate) {
   var bashoInfo = parseBashoDate(endedBashoDate);
   var tableTitle = document.getElementsByClassName("tableTitle");
-  
-  // Current basho title
+
   tableTitle[0].innerHTML = getBashoName(bashoInfo.month) + ' ' + bashoInfo.year;
-  
+
   // Next basho title
   var nextBasho = getNextBasho(bashoInfo.year, bashoInfo.month);
   tableTitle[1].innerHTML = getBashoName(nextBasho.month) + ' ' + nextBasho.year + 

--- a/basho-utils.js
+++ b/basho-utils.js
@@ -1,62 +1,57 @@
 // Basho Utilities Module - Handles basho date and naming logic
 
-(function() {
-  'use strict';
-  
-  // Basho name lookup table
-  const bashoMonthLookup = {
-    1: "Hatsu", 
-    3: "Haru", 
-    5: "Natsu", 
-    7: "Nagoya", 
-    9: "Aki",
-    11: "Kyushu"
+// Basho name lookup table
+const bashoMonthLookup = {
+  1: "Hatsu", 
+  3: "Haru", 
+  5: "Natsu", 
+  7: "Nagoya", 
+  9: "Aki",
+  11: "Kyushu"
+};
+
+// Get basho name from month number
+export function getBashoName(month) {
+  return bashoMonthLookup[month];
+}
+
+// Parse basho date string
+export function parseBashoDate(bashoDateString) {
+  return {
+    year: parseInt(bashoDateString.substring(0, 4)),
+    month: parseInt(bashoDateString.slice(-2))
   };
-  
-  // Get basho name from month number
-  function getBashoName(month) {
-    return bashoMonthLookup[month];
+}
+
+// Get next basho info
+export function getNextBasho(year, month) {
+  if (month > 9) {
+    year++;
+    month = 1;
+  } else {
+    month += 2;
   }
+  return { year, month };
+}
+
+// Write table titles for current and next basho
+export function writeTableTitles(endedBashoDate) {
+  var bashoInfo = parseBashoDate(endedBashoDate);
+  var tableTitle = document.getElementsByClassName("tableTitle");
   
-  // Parse basho date string
-  function parseBashoDate(bashoDateString) {
-    return {
-      year: parseInt(bashoDateString.substring(0, 4)),
-      month: parseInt(bashoDateString.slice(-2))
-    };
-  }
+  // Current basho title
+  tableTitle[0].innerHTML = getBashoName(bashoInfo.month) + ' ' + bashoInfo.year;
   
-  // Get next basho info
-  function getNextBasho(year, month) {
-    if (month > 9) {
-      year++;
-      month = 1;
-    } else {
-      month += 2;
-    }
-    return { year, month };
-  }
-  
-  // Write table titles for current and next basho
-  function writeTableTitles(endedBashoDate) {
-    var bashoInfo = parseBashoDate(endedBashoDate);
-    var tableTitle = document.getElementsByClassName("tableTitle");
-    
-    // Current basho title
-    tableTitle[0].innerHTML = getBashoName(bashoInfo.month) + ' ' + bashoInfo.year;
-    
-    // Next basho title
-    var nextBasho = getNextBasho(bashoInfo.year, bashoInfo.month);
-    tableTitle[1].innerHTML = getBashoName(nextBasho.month) + ' ' + nextBasho.year + 
-                              " Guess - " + tableTitle[1].innerHTML;
-  }
-  
-  // Export functions to global scope
-  window.bashoUtils = {
-    writeTableTitles: writeTableTitles,
-    getBashoName: getBashoName,
-    parseBashoDate: parseBashoDate,
-    getNextBasho: getNextBasho
-  };
-  
-})();
+  // Next basho title
+  var nextBasho = getNextBasho(bashoInfo.year, bashoInfo.month);
+  tableTitle[1].innerHTML = getBashoName(nextBasho.month) + ' ' + nextBasho.year + 
+                            " Guess - " + tableTitle[1].innerHTML;
+}
+
+// Also maintain backward compatibility with window.bashoUtils
+window.bashoUtils = {
+  writeTableTitles,
+  getBashoName,
+  parseBashoDate,
+  getNextBasho
+};

--- a/drag-drop-manager.js
+++ b/drag-drop-manager.js
@@ -1,20 +1,17 @@
 // Drag and Drop Manager - Clean abstraction over REDIPS library
 
-(function() {
-  'use strict';
+// Private variables
+let rd = null;
+let config = {
+  oldBanzukeSelector: 'td',
+  newBanzukeClass: 'b2',
+  changeColumnClass: 'ch',
+  rikishiCounterId: 'makRik',
+  tableLinerId: 'tableLiner'
+};
   
-  // Private variables
-  let rd = null;
-  let config = {
-    oldBanzukeSelector: 'td',
-    newBanzukeClass: 'b2',
-    changeColumnClass: 'ch',
-    rikishiCounterId: 'makRik',
-    tableLinerId: 'tableLiner'
-  };
-  
-  // Initialize drag and drop functionality
-  function initialize() {
+// Initialize drag and drop functionality
+export function init() {
     rd = REDIPS.drag;
     rd.init();
     
@@ -34,8 +31,8 @@
     window.rikishiNames.makeEditable();
   }
   
-  // Set up rank-based movement restrictions
-  function setupRankRestrictions() {
+// Set up rank-based movement restrictions
+function setupRankRestrictions() {
     for (var i = 0; i < theSekitori.length; i++) {
       if (theSekitori[i] !== "") {
         var rank = theSekitori[i].split(' ')[0];
@@ -44,8 +41,8 @@
     }
   }
   
-  // Set up all event handlers
-  function setupEventHandlers() {
+// Set up all event handlers
+function setupEventHandlers() {
     rd.event.dblClicked = handleDoubleClick;
     rd.event.clicked = handleClick;
     rd.event.notMoved = handleNotMoved;
@@ -54,8 +51,8 @@
     rd.event.finish = handleFinish;
   }
   
-  // Handle double-click on rikishi
-  function handleDoubleClick() {
+// Handle double-click on rikishi
+function handleDoubleClick() {
     var draggedElement = rd.obj;
     var currentCell = rd.findParent('TD', draggedElement);
     var radioButtons = document.getElementsByTagName("input");
@@ -70,8 +67,8 @@
     }
   }
   
-  // Return rikishi to old banzuke position
-  function returnToOldBanzuke(draggedElement, currentCell) {
+// Return rikishi to old banzuke position
+function returnToOldBanzuke(draggedElement, currentCell) {
     var rank = draggedElement.id;
     var oldBanzukeCells = document.getElementsByTagName(config.oldBanzukeSelector);
     
@@ -94,19 +91,19 @@
     }
   }
   
-  // Handle click on element
-  function handleClick(currentCell) {
+// Handle click on element
+function handleClick(currentCell) {
     currentCell.style.backgroundColor = "lightblue";
   }
   
-  // Handle when element is clicked but not moved
-  function handleNotMoved() {
+// Handle when element is clicked but not moved
+function handleNotMoved() {
     var currentCell = rd.findParent('TD', rd.obj);
     currentCell.style.removeProperty("background-color");
   }
   
-  // Handle before drop event
-  function handleDroppedBefore(targetCell) {
+// Handle before drop event
+function handleDroppedBefore(targetCell) {
     var draggedElement = rd.obj;
     var currentCell = rd.findParent('TD', draggedElement);
     
@@ -121,8 +118,8 @@
     }
   }
   
-  // Update cell visual state based on movement
-  function updateCellVisualState(currentCell, targetCell) {
+// Update cell visual state based on movement
+function updateCellVisualState(currentCell, targetCell) {
     var isFromNew = currentCell.classList.contains(config.newBanzukeClass);
     var isToNew = targetCell.classList.contains(config.newBanzukeClass);
     
@@ -139,8 +136,8 @@
     }
   }
   
-  // Handle dropped event
-  function handleDropped(targetCell) {
+// Handle dropped event
+function handleDropped(targetCell) {
     if (!targetCell.classList.contains(config.newBanzukeClass)) {
       return;
     }
@@ -150,8 +147,8 @@
     updateChangeDisplay(targetCell, changeInfo);
   }
   
-  // Calculate rank change information
-  function calculateRankChange(draggedElement, targetCell) {
+// Calculate rank change information
+function calculateRankChange(draggedElement, targetCell) {
     var currentRank = draggedElement.id;
     var wins = draggedElement.innerText.split(' ')[2].split('-')[0];
     var targetRank = getTargetRank(targetCell);
@@ -165,8 +162,8 @@
     };
   }
   
-  // Get target rank from cell position
-  function getTargetRank(targetCell) {
+// Get target rank from cell position
+function getTargetRank(targetCell) {
     if (targetCell.previousSibling.className === config.changeColumnClass) {
       return targetCell.nextSibling.innerHTML + 'e';
     } else if (targetCell.nextSibling.className === config.changeColumnClass) {
@@ -175,8 +172,8 @@
     return '';
   }
   
-  // Get rank change symbol
-  function getChangeSymbol(currentRank, targetRank) {
+// Get rank change symbol
+function getChangeSymbol(currentRank, targetRank) {
     var currentType = currentRank.charAt(0);
     var targetType = targetRank.charAt(0);
     
@@ -212,8 +209,8 @@
     }
   }
   
-  // Calculate change between Maegashira ranks
-  function calculateMaegashiraChange(currentRank, targetRank) {
+// Calculate change between Maegashira ranks
+function calculateMaegashiraChange(currentRank, targetRank) {
     var currentNum = parseInt(currentRank.slice(1, -1));
     var targetNum = parseInt(targetRank.slice(1, -1));
     
@@ -228,8 +225,8 @@
     else return change.toString();
   }
   
-  // Update change display in the change column
-  function updateChangeDisplay(targetCell, changeInfo) {
+// Update change display in the change column
+function updateChangeDisplay(targetCell, changeInfo) {
     var changeCell = getChangeCell(targetCell);
     if (!changeCell) return;
     
@@ -243,8 +240,8 @@
     }
   }
   
-  // Get the change cell for a target cell
-  function getChangeCell(targetCell) {
+// Get the change cell for a target cell
+function getChangeCell(targetCell) {
     if (targetCell.previousSibling.className === config.changeColumnClass) {
       return targetCell.previousSibling;
     } else if (targetCell.nextSibling.className === config.changeColumnClass) {
@@ -253,8 +250,8 @@
     return null;
   }
   
-  // Create SumoDB query link for rank change
-  function createChangeLink(changeInfo) {
+// Create SumoDB query link for rank change
+function createChangeLink(changeInfo) {
     var url = 'https://sumodb.sumogames.de/Query.aspx?show_form=0' +
               '&form1_rank=' + changeInfo.currentRank +
               '&form1_wins=' + changeInfo.wins +
@@ -266,8 +263,8 @@
            changeInfo.symbol + '</a>';
   }
   
-  // Update change column when removing rikishi
-  function updateChangeColumn(cell, draggedElement) {
+// Update change column when removing rikishi
+function updateChangeColumn(cell, draggedElement) {
     var changeCell = getChangeCell(cell);
     if (!changeCell) return;
     
@@ -288,29 +285,34 @@
     }
   }
   
-  // Update rikishi count display
-  function updateRikishiCount(delta) {
+// Update rikishi count display
+function updateRikishiCount(delta) {
     var counter = document.getElementById(config.rikishiCounterId);
     if (counter) {
       counter.innerHTML = parseInt(counter.innerHTML) + delta;
     }
   }
   
-  // Save banzuke state to localStorage
-  function saveBanzukeState() {
-    var tableLiner = document.getElementById(config.tableLinerId);
-    if (tableLiner) {
-      window.localStorage.setItem("banzuke", tableLiner.innerHTML);
-    }
+// Save banzuke state to localStorage
+export function saveState() {
+  var tableLiner = document.getElementById(config.tableLinerId);
+  if (tableLiner) {
+    window.localStorage.setItem("banzuke", tableLiner.innerHTML);
   }
+}
+
+// Internal save function for event handlers
+function saveBanzukeState() {
+  saveState();
+}
   
-  // Handle finish event
-  function handleFinish() {
+// Handle finish event
+function handleFinish() {
     saveBanzukeState();
   }
   
-  // Reset banzuke to initial state
-  function resetBanzuke() {
+// Reset banzuke to initial state
+export function reset() {
     if (!confirm("Reset the banzuke?")) {
       return;
     }
@@ -351,11 +353,17 @@
     }
   }
   
-  // Export public API
-  window.dragDropManager = {
-    init: initialize,
-    reset: resetBanzuke,
-    saveState: saveBanzukeState
-  };
+// Reinitialize a specific card for drag functionality
+export function reinitializeCard(card) {
+    if (rd && card.className.includes('redips-drag')) {
+      rd.enableDrag(true, card);
+    }
+  }
   
-})();
+// Also maintain backward compatibility with window.dragDropManager
+window.dragDropManager = {
+  init,
+  reset,
+  saveState,
+  reinitializeCard
+};

--- a/index.html
+++ b/index.html
@@ -8,10 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script type="text/javascript" src="test/redips-drag-min.js"></script>
   <script type="text/javascript" src="https://momentjs.com/downloads/moment.js"></script>
-  <script type="module" src="rikishi-names.js"></script>
-  <script type="module" src="basho-utils.js"></script>
-  <script type="module" src="rikishi-card-manager.js"></script>
-  <script type="module" src="drag-drop-manager.js"></script>
+  <script type="module" src="modules-init.js"></script>
   <script type="text/javascript" src="test/script.js" defer></script>
   <link rel="stylesheet" href="test/styles.css" type="text/css"/>
   <title>GTB Helper - Claude Code Edition</title>

--- a/index.html
+++ b/index.html
@@ -8,11 +8,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script type="text/javascript" src="test/redips-drag-min.js"></script>
   <script type="text/javascript" src="https://momentjs.com/downloads/moment.js"></script>
-  <script type="text/javascript" src="rikishi-names.js"></script>
-  <script type="text/javascript" src="basho-utils.js"></script>
-  <script type="text/javascript" src="rikishi-card-manager.js"></script>
-  <script type="text/javascript" src="drag-drop-manager.js"></script>
-  <script type="text/javascript" src="test/script.js"></script>
+  <script type="module" src="rikishi-names.js"></script>
+  <script type="module" src="basho-utils.js"></script>
+  <script type="module" src="rikishi-card-manager.js"></script>
+  <script type="module" src="drag-drop-manager.js"></script>
+  <script type="text/javascript" src="test/script.js" defer></script>
   <link rel="stylesheet" href="test/styles.css" type="text/css"/>
   <title>GTB Helper - Claude Code Edition</title>
 </head>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <script type="text/javascript" src="https://momentjs.com/downloads/moment.js"></script>
   <script type="text/javascript" src="rikishi-names.js"></script>
   <script type="text/javascript" src="basho-utils.js"></script>
+  <script type="text/javascript" src="rikishi-card-manager.js"></script>
   <script type="text/javascript" src="drag-drop-manager.js"></script>
   <script type="text/javascript" src="test/script.js"></script>
   <link rel="stylesheet" href="test/styles.css" type="text/css"/>

--- a/modules-init.js
+++ b/modules-init.js
@@ -1,0 +1,15 @@
+// Module initialization - ensures all modules are loaded in correct order
+
+// Import all modules
+import './rikishi-names.js';
+import './basho-utils.js';
+import './rikishi-card-manager.js';
+import './drag-drop-manager.js';
+
+// Signal that modules are ready
+window.modulesReady = true;
+
+// If script.js already loaded and waiting, initialize now
+if (window.pendingInit) {
+  window.pendingInit();
+}

--- a/previous.html
+++ b/previous.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="styles.css" type="text/css" />
     <title>Previous Basho</title>
+    
+    <script type="module">
+      import { writeTableTitles, getBashoName } from './basho-utils.js';
+      import { load as loadRikishiNames, save as saveRikishiNames } from './rikishi-names.js';
+      import { createCard, populateAllSlots } from './rikishi-card-manager.js';
+      import { init as initDragDrop, reset as resetBanzuke } from './drag-drop-manager.js';
+      
+      console.log('Modules imported:', { writeTableTitles, loadRikishiNames, createCard, initDragDrop });
+    </script>
   </head>
   <body class="darkm">
     <script>
@@ -5675,5 +5684,14 @@
       <br />
       Open source GTB helper tool
     </footer>
+    
+    <!-- ES6 Module Support Test -->
+    <script type="module">
+      console.log('✅ ES6 modules are supported!');
+      // We could refactor to use ES6 modules instead of IIFE pattern
+    </script>
+    <script nomodule>
+      console.log('❌ ES6 modules NOT supported - keeping IIFE pattern');
+    </script>
   </body>
 </html>

--- a/rikishi-card-manager.js
+++ b/rikishi-card-manager.js
@@ -1,5 +1,7 @@
 // Rikishi Card Manager - Handles creation and management of rikishi cards
 
+import { theSekitori, sekitoriID } from './rikishi-names.js';
+
 // Storage keys
 const RETIRED_RIKISHI_KEY = 'retiredRikishi';
 const CUSTOM_NAMES_KEY = 'customRikishiNames';

--- a/rikishi-card-manager.js
+++ b/rikishi-card-manager.js
@@ -1,0 +1,186 @@
+// Rikishi Card Manager - Handles creation and management of rikishi cards
+
+// Storage keys
+const RETIRED_RIKISHI_KEY = 'retiredRikishi';
+const CUSTOM_NAMES_KEY = 'customRikishiNames';
+  
+// Get retired rikishi from localStorage
+function getRetiredRikishi() {
+    const stored = localStorage.getItem(RETIRED_RIKISHI_KEY);
+    return stored ? JSON.parse(stored) : {};
+  }
+  
+// Save retired rikishi to localStorage
+function saveRetiredRikishi(retiredMap) {
+    localStorage.setItem(RETIRED_RIKISHI_KEY, JSON.stringify(retiredMap));
+  }
+  
+// Mark a rikishi as retired
+function markAsRetired(rikishiId) {
+    const retired = getRetiredRikishi();
+    retired[rikishiId] = true;
+    saveRetiredRikishi(retired);
+  }
+  
+// Mark a rikishi as active (unretire)
+function markAsActive(rikishiId) {
+    const retired = getRetiredRikishi();
+    delete retired[rikishiId];
+    saveRetiredRikishi(retired);
+  }
+  
+// Check if a rikishi is retired
+function isRetired(rikishiId) {
+    const retired = getRetiredRikishi();
+    return retired[rikishiId] === true;
+  }
+  
+// Create a rikishi card element
+export function createCard(rikishiData, rikishiId, basho) {
+    const rikiData = rikishiData.split(' ');
+    const card = document.createElement('div');
+    
+    // Set basic attributes
+    card.setAttribute('id', rikiData[0]);
+    card.setAttribute('data-rid', rikishiId);
+    
+    // Get custom name if exists
+    const customNames = window.rikishiNames.load();
+    const displayName = customNames[rikishiId] || rikiData[1];
+    
+    // Create record link
+    rikiData[2] = `<a href="https://sumodb.sumogames.de/Rikishi_basho.aspx?r=${rikishiId}&b=${basho}" target="_blank">${rikiData[2]}</a>`;
+    
+    // Create name link
+    rikiData[1] = `<a href="https://sumodb.sumogames.de/Rikishi.aspx?r=${rikishiId}" target="_blank">${displayName}</a>`;
+    
+    // Apply retired styling if needed
+    if (isRetired(rikishiId)) {
+      card.className = 'redips-nodrag';
+      card.style.backgroundColor = '#dadada';
+      card.style.cursor = 'not-allowed';
+      card.style.color = '#3c3c3c';
+      card.setAttribute('title', 'Retired - Right-click to toggle retirement status');
+    } else {
+      card.className = 'redips-drag se';
+      card.style.cursor = 'grab';
+      card.setAttribute('title', 'Right-click to mark as retired');
+    }
+    
+    card.innerHTML = rikiData.join(' ');
+    
+    // Add right-click handler for retirement toggle
+    card.addEventListener('contextmenu', function(e) {
+      e.preventDefault();
+      toggleRetirement(rikishiId, card);
+    });
+    
+    return card;
+  }
+  
+// Toggle retirement status
+function toggleRetirement(rikishiId, card) {
+    if (isRetired(rikishiId)) {
+      if (confirm('Mark this rikishi as active?')) {
+        markAsActive(rikishiId);
+        // Update card appearance
+        card.className = 'redips-drag se';
+        card.style.backgroundColor = '';
+        card.style.cursor = 'grab';
+        card.style.color = '';
+        card.setAttribute('title', 'Right-click to mark as retired');
+        // Re-initialize drag functionality for this card
+        if (window.dragDropManager && window.dragDropManager.reinitializeCard) {
+          window.dragDropManager.reinitializeCard(card);
+        }
+      }
+    } else {
+      if (confirm('Mark this rikishi as retired?')) {
+        markAsRetired(rikishiId);
+        // Update card appearance
+        card.className = 'redips-nodrag';
+        card.style.backgroundColor = '#dadada';
+        card.style.cursor = 'not-allowed';
+        card.style.color = '#3c3c3c';
+        card.setAttribute('title', 'Retired - Right-click to toggle retirement status');
+      }
+    }
+    
+    // Save the updated banzuke state
+    saveBanzukeState();
+  }
+  
+// Populate all rikishi slots
+export function populateAllSlots(basho) {
+    const cells = document.querySelectorAll('.redips-only');
+    
+    for (let i = 0; i < theSekitori.length; i++) {
+      if (theSekitori[i] !== '') {
+        // Create card
+        const card = createCard(theSekitori[i], sekitoriID[i], basho);
+        
+        // Create holder (hidden span)
+        const holder = document.createElement('span');
+        holder.innerHTML = card.innerHTML;
+        holder.style.display = 'none';
+        
+        // Append to cell
+        cells[i].appendChild(holder);
+        cells[i].appendChild(card);
+      }
+    }
+  }
+  
+// Save banzuke state
+function saveBanzukeState() {
+    const tableLiner = document.getElementById('tableLiner');
+    if (tableLiner) {
+      localStorage.setItem('banzuke', tableLiner.innerHTML);
+    }
+  }
+  
+// Migrate old hardcoded retired rikishi
+function migrateHardcodedRetired() {
+    const retired = getRetiredRikishi();
+    let needsSave = false;
+    
+    // Check each rikishi for hardcoded retirement
+    for (let i = 0; i < theSekitori.length; i++) {
+      if (theSekitori[i] !== '') {
+        const rikiData = theSekitori[i].split(' ');
+        const rikishiId = sekitoriID[i];
+        
+        // Check for Chiyotairyu or Yutakayama
+        if (rikiData[1] === 'Chiyotairyu' || rikiData[1] === 'Yutakayama') {
+          if (!retired[rikishiId]) {
+            retired[rikishiId] = true;
+            needsSave = true;
+          }
+        }
+      }
+    }
+    
+    if (needsSave) {
+      saveRetiredRikishi(retired);
+    }
+  }
+  
+// Initialize the module
+export function init() {
+    // Run migration on first load
+    if (!localStorage.getItem('retiredMigrationDone')) {
+      migrateHardcodedRetired();
+      localStorage.setItem('retiredMigrationDone', 'true');
+    }
+  }
+  
+// Also maintain backward compatibility with window.rikishiCardManager
+window.rikishiCardManager = {
+  init,
+  createCard,
+  populateAllSlots,
+  isRetired,
+  markAsRetired,
+  markAsActive,
+  getRetiredRikishi
+};

--- a/rikishi-names.js
+++ b/rikishi-names.js
@@ -166,11 +166,8 @@ var sekitoriID = [
   11943
 ];
 
-(function() {
-  'use strict';
-  
-  // Load custom rikishi names from localStorage
-  function loadCustomRikishiNames() {
+// Load custom rikishi names from localStorage
+export function load() {
     var customNames = localStorage.getItem('customRikishiNames');
     if (customNames) {
       return JSON.parse(customNames);
@@ -178,14 +175,14 @@ var sekitoriID = [
     return {};
   }
 
-  // Save custom rikishi names to localStorage
-  function saveCustomRikishiNames(customNames) {
+// Save custom rikishi names to localStorage
+export function save(customNames) {
     localStorage.setItem('customRikishiNames', JSON.stringify(customNames));
   }
 
-  // Make rikishi names editable
-  function makeRikishiNamesEditable() {
-    var customNames = loadCustomRikishiNames();
+// Make rikishi names editable
+export function makeEditable() {
+  var customNames = load();
     
     // Add click event to all rikishi name links
     document.addEventListener('click', function(e) {
@@ -218,12 +215,12 @@ var sekitoriID = [
           var newName = input.value.trim();
           if (newName && newName !== currentName) {
             customNames[rikishiId] = newName;
-            saveCustomRikishiNames(customNames);
+            save(customNames);
             e.target.textContent = newName;
           } else if (newName === '') {
             // If empty, revert to original name
             delete customNames[rikishiId];
-            saveCustomRikishiNames(customNames);
+            save(customNames);
             e.target.textContent = currentName;
           }
           input.remove();
@@ -258,11 +255,9 @@ var sekitoriID = [
     });
   }
   
-  // Export functions to global scope
-  window.rikishiNames = {
-    load: loadCustomRikishiNames,
-    save: saveCustomRikishiNames,
-    makeEditable: makeRikishiNamesEditable
-  };
-  
-})();
+// Also maintain backward compatibility with window.rikishiNames
+window.rikishiNames = {
+  load,
+  save,
+  makeEditable
+};

--- a/rikishi-names.js
+++ b/rikishi-names.js
@@ -6,7 +6,7 @@
  * in between the record and special letter Y, S, DK ... As ' ' 
  * is not considered a regular whitespace, it will not expand.
  */ 
-var theSekitori = [
+export const theSekitori = [
   "Y1e Hoshoryu 0-0", 
   "Y1w Onosato 0-0", 
   "O1e Kotozakura 0-0", 
@@ -89,7 +89,7 @@ var theSekitori = [
  * array (add the empty spots as 0). This array should have the same length as 
  * theSekitori array.
  */
-var sekitoriID = [
+export const sekitoriID = [
   12451, 
   12453, 
   12270, 
@@ -261,3 +261,7 @@ window.rikishiNames = {
   save,
   makeEditable
 };
+
+// Export arrays to window for backward compatibility
+window.theSekitori = theSekitori;
+window.sekitoriID = sekitoriID;

--- a/test/script.js
+++ b/test/script.js
@@ -4,7 +4,7 @@
 var basho = "202301";
 
 // Initialize application when DOM is ready
-window.onload = function() {
+function initializeApp() {
   // Clean up old storage format
   if (window.localStorage.getItem("banzuke1") !== null) {
     window.localStorage.removeItem("banzuke1");
@@ -45,4 +45,13 @@ function saveRadio(radioButton) {
 // Reset banzuke function for onclick handler
 function resetBanzuke() {
   window.dragDropManager.reset();
+}
+
+// Wait for modules to be ready
+window.onload = function() {
+  if (window.modulesReady) {
+    initializeApp();
+  } else {
+    window.pendingInit = initializeApp;
+  }
 }

--- a/test/script.js
+++ b/test/script.js
@@ -1,86 +1,43 @@
-//***** Just update the "basho" variable and you're all done. *****
+// GTB Helper - Main Application Entry Point
 
-// These need to be global for other functions to access
-var basho = "202301"; // The date of the basho just ended
+// Global basho date - update this after each tournament
+var basho = "202301";
 
+// Initialize application when DOM is ready
 window.onload = function() {
-
+  // Clean up old storage format
   if (window.localStorage.getItem("banzuke1") !== null) {
     window.localStorage.removeItem("banzuke1");
     window.localStorage.removeItem("banzuke2");
   }
+  
+  // Initialize modules
+  window.rikishiCardManager.init();
+  
+  // Set up the banzuke
   if (window.localStorage.getItem("banzuke") === null) {
     window.bashoUtils.writeTableTitles(basho);
-    populateSlots();
-  }
-  else {
+    window.rikishiCardManager.populateAllSlots(basho);
+  } else {
     document.getElementById("tableLiner").innerHTML = 
-    window.localStorage.getItem("banzuke");
+      window.localStorage.getItem("banzuke");
   }
-
-  var radioButton = document.getElementsByClassName("checkbox"), 
-      radioLocal  = window.localStorage.getItem("radioButton");
-
-  if (radioLocal === null || radioLocal == "openRikishiPage")
+  
+  // Set up radio button preferences
+  var radioButton = document.getElementsByClassName("checkbox");
+  var radioLocal = window.localStorage.getItem("radioButton");
+  
+  if (radioLocal === null || radioLocal == "openRikishiPage") {
     radioButton[0].checked = true;
-  else 
+  } else {
     radioButton[1].checked = true;
-
-
-  function populateSlots() {
-    var cell = document.querySelectorAll(".redips-only");
-    var customNames = window.rikishiNames.load();
-    
-    for (var i = 0; i < theSekitori.length; i++) {
-      if (theSekitori[i] !== "") {
-        var card     = document.createElement("div"), 
-            rikiData = theSekitori[i].split(' ');
-
-        card.setAttribute("id", rikiData[0]);
-        card.className = "redips-drag se";
-        card.setAttribute("data-rid", sekitoriID[i]);
-
-        /*
-        if (rikiData[2].split('-')[0] < 8) 
-          card.style.backgroundColor = "#ffd2d2";
-        else 
-          card.style.backgroundColor = "#c2ff9f";
-        */
-
-        rikiData[2] = '<a href="https://sumodb.sumogames.de/Rikishi_basho.aspx?r=' + 
-                      sekitoriID[i] + "&b=" + basho + '" target="_blank">' + rikiData[2] + "</a>";
-
-        card.innerHTML = rikiData.join(' ');
-        
-        // Apply custom name if exists
-        var displayName = customNames[sekitoriID[i]] || rikiData[1];
-
-        rikiData[1] = '<a href="https://sumodb.sumogames.de/Rikishi.aspx?r=' + 
-                      sekitoriID[i] + '" target="_blank">' + displayName + "</a>";
-
-        if (rikiData[1].includes("Chiyotairyu") || rikiData[1].includes("Yutakayama")) {
-          card.innerHTML = rikiData.join(' ');
-          card.style.backgroundColor = "#dadada";
-          card.style.cursor = "text";
-          card.style.color = "#3c3c3c";
-          card.className = "redips-nodrag";
-          card.setAttribute("title", "Retired");
-        }
-
-        var holder = document.createElement("span");
-        holder.innerHTML = rikiData.join(' ');
-        holder.style.display = "none";
-
-        cell[i].appendChild(holder);
-        cell[i].appendChild(card);
-      }
-    }
   }
   
   // Initialize drag and drop functionality
   window.dragDropManager.init();
 }
 
+// Save radio button preference
 function saveRadio(radioButton) {
   window.localStorage.setItem("radioButton", radioButton.value);
 }


### PR DESCRIPTION
## Summary
- Remove hardcoded exceptions for retired rikishi (Chiyotairyu/Yutakayama)
- Implement localStorage-based retired rikishi management with right-click toggle
- Convert all JavaScript modules from IIFE to ES6 export syntax
- Fix module loading order issues with centralized initialization

## Changes
1. **Retired rikishi handling**:
   - Created rikishi-card-manager.js module to handle card creation and management
   - Store retired status in localStorage instead of hardcoded checks
   - Add right-click functionality to toggle retirement status
   - Migrate existing hardcoded retired rikishi on first load
   - Visual styling for retired rikishi (grayed out, not draggable)

2. **ES6 module conversion**:
   - basho-utils.js - Converted to ES6 exports
   - drag-drop-manager.js - Converted to ES6 exports (including reinitializeCard function)
   - rikishi-names.js - Converted to ES6 exports (including theSekitori/sekitoriID arrays)
   - rikishi-card-manager.js - Built with ES6 exports from start
   - All modules maintain backward compatibility with window object

3. **Module loading fixes**:
   - Created modules-init.js as centralized entry point
   - Updated index.html to use type="module" for ES6 modules
   - Fixed import/export dependencies between modules
   - Ensured proper loading order to prevent reference errors